### PR TITLE
Quote URLs for download via `wget`

### DIFF
--- a/docs/source/Installation.rst
+++ b/docs/source/Installation.rst
@@ -13,8 +13,8 @@ Just download the singlularity image with:
   .. code-block:: bash
 
 
-    wget -O Demuxafy.sif https://www.dropbox.com/scl/fi/g0cuyjwomdavom6u6kb2v/Demuxafy.sif?rlkey=xfey1agg371jo4lubsljfavkh&
-    wget -O Demuxafy.sif.md5 https://www.dropbox.com/scl/fi/bk3p2k2440un6sb6psijn/Demuxafy.sif.md5?rlkey=x3vl8ejpfhjsrvmjanwzkxty9
+    wget -O Demuxafy.sif 'https://www.dropbox.com/scl/fi/g0cuyjwomdavom6u6kb2v/Demuxafy.sif?rlkey=xfey1agg371jo4lubsljfavkh&'
+    wget -O Demuxafy.sif.md5 'https://www.dropbox.com/scl/fi/bk3p2k2440un6sb6psijn/Demuxafy.sif.md5?rlkey=x3vl8ejpfhjsrvmjanwzkxty9'
 
 
 


### PR DESCRIPTION
The trailing `&` in the latest image's URL causes the shell to send `wget` to the background attempting to download from a invalid (because incomplete) URL. Wrapping the URLs into single-quotes should remedy this and similar problems.

If my interpretation is wrong and the download was supposed to be send to the background, I still recommend wrapping the URLs themselves in single quotes and separating the `&` by a space for clarity.