### PR TITLE
Fix reference: UCSC -> Ensembl

### DIFF
--- a/docs/source/DataPrep.rst
+++ b/docs/source/DataPrep.rst
@@ -145,7 +145,7 @@ Test Dataset
 In addition, we have provided a test dataset that you can use.
 Find the data that can be downloaded below along with some information about the data.
 The data have been aligned to GRCh38 so for running.
-If you are running souporcell, you will needa a fasta file, which you can download from `UCSC FTP <https://asia.ensembl.org/info/data/ftp/index.html>`__
+If you are running souporcell, you will needa a fasta file, which you can download from `Ensembl FTP <https://asia.ensembl.org/info/data/ftp/index.html>`__
 
 .. admonition:: Information
   :class: important


### PR DESCRIPTION
The link correctly points to Ensembl but is labeled UCSC which implies the wrong chromosome naming style (lack of `chr` prefix) which can trigger https://github.com/drneavin/Demultiplexing_Doublet_Detecting_Docs/issues/39.