### PR TITLE
Demuxalot: Adjust script for v. 0.4.0

### DIFF
--- a/scripts/Demuxalot.py
+++ b/scripts/Demuxalot.py
@@ -50,7 +50,6 @@ likelihoods, posterior_probabilities = Demultiplexer.predict_posteriors(
     snps,
     genotypes=genotypes,
     barcode_handler=barcode_handler,
-    only_singlets=False
 )
 
 print("writing unrefined results")
@@ -71,7 +70,6 @@ if args.refine:
         snps,
         genotypes=refined_genotypes,
         barcode_handler=barcode_handler,
-        only_singlets=False,
     )
 
     print("writing second set of output")


### PR DESCRIPTION
Demuxalot changed its API between the version currently included in the Demuxafy Singularity image (v. 0.2.0) and the latest (as of 2024-02-22) version (v. 0.4.0):

Notably, the `only_singlets` parameter of the `predict_posteriors` function was dropped (see
herophilus/demuxalot@3939e81059247919cfbb9a53975ea82713487b91). However, as far as I can tell, as long as the `doublet_prior` parameter is non-zero, the it defaults to the behaviour of `only_singlets = FALSE` (cf. herophilus/demuxalot@2b1535b75fc4e42823e2fcf0868231f93b4c281d).

As Demuxafy's `Demuxalot.py` uses, `only_singlets = FALSE` and `doublet_prior` defaults to `0.35` (i.e. a non-zero value), simply dropping the (now) unsupported parameter restores compatibility of Demuxafy's `Demuxalot.py` with the current version of Demuxalot.

I have verified that the adjusted version of Demuxafy's `Demuxalot.py` works with Demuxalot v. 0.4.0 by running the corresponding tutorial (with the reduced dataset) as a test case.
The final (refined) assignments (as per `assignments_refined.tsv.gz`) were identical to those obtained by running the current version from the Demuxafy Singularity image.

---
As usual with my PR's this one adds a final newline to the script due to my editor configuration.

@drneavin: I could not find any place in the repository that actually defines which version of Demuxalot to include in the Demuxafy Singularity image. Else I would have bumped the version accordingly.
So please ensure that upon mergin this PR you also update Demuxafy via pip.
If I just missed it, please point me to it so I can modify this PR accordingly.