### PR TITLE
Add support for non- Cell Ranger SAM tags

### DIFF
--- a/docs/source/Demuxalot.rst
+++ b/docs/source/Demuxalot.rst
@@ -40,6 +40,15 @@ This is the data that you will need to have prepare to run Demuxalot_:
 
       - For example, this is the :download:`individual file <_download_files/Individuals.txt>` for our example dataset
 
+.. admonition:: Optional
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding cell barcode (``$CELL_TAG``)
+
+      - If not specified, _Demuxalot defaults to using ``CB`` as that flag is used by Cell Ranger.
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding unique molecular identifier (UMI) (``$UMI_TAG``)
+
+      - If not specified, _Demuxalot defaults to using ``UB`` as that flag is used by Cell Ranger.
 
 
 Run Demuxalot
@@ -86,6 +95,8 @@ Demultiplex with Demuxalot
               -v $VCF \
               -o $DEMUXALOT_OUTDIR \
               -p $THREADS \
+              ${CELL_TAG:+-c $CELL_TAG} \
+              ${UMI_TAG:+-u $UMI_TAG} \
               -r True
 
     .. admonition:: HELP! It says my file/directory doesn't exist!

--- a/docs/source/Demuxlet.rst
+++ b/docs/source/Demuxlet.rst
@@ -46,6 +46,14 @@ This is the data that you will need to have prepare to run Demuxlet_:
 
       - For example, this is the :download:`individual file <_download_files/Individuals.txt>` for our example dataset
 
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding cell barcode (``$CELL_TAG``)
+
+      - If not specified, _Demuxlet defaults to using ``CB``.
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding unique molecular identifier (UMI) (``$UMI_TAG``)
+
+      - If not specified, _Demuxlet defaults to using ``UB``.
+
 
 Run Demuxlet
 ------------
@@ -89,6 +97,8 @@ First we will need to identify the number of reads from each allele at each SNP 
       --sam $BAM \
       --vcf $VCF \
       --group-list $BARCODES \
+      ${CELL_TAG:+--tag-group $CELL_TAG} \
+      ${UMI_TAG:+--tag-UMI $UMI_TAG} \
       --out $DEMUXLET_OUTDIR/pileup \
       --sm-list $INDS
 
@@ -108,7 +118,7 @@ First we will need to identify the number of reads from each allele at each SNP 
 
     .. code-block:: bash
 
-      singularity exec Demuxafy.sif popscle dsc-pileup --sam $BAM --vcf $VCF --group-list $BARCODES --out $DEMUXLET_OUTDIR/pileup
+      singularity exec Demuxafy.sif popscle dsc-pileup --sam $BAM --vcf $VCF --group-list $BARCODES ${CELL_TAG:+--tag-group $CELL_TAG} ${UMI_TAG:+--tag-UMI $UMI_TAG} --out $DEMUXLET_OUTDIR/pileup
 
     .. admonition:: HELP! It says my file/directory doesn't exist!
       :class: dropdown
@@ -149,7 +159,7 @@ Once you have run ``popscle pileup``, you can demultiplex your samples:
 
     .. code-block:: bash
 
-      singularity exec Demuxafy.sif popscle demuxlet --plp $DEMUXLET_OUTDIR/pileup --vcf $VCF --field $FIELD --group-list $BARCODES --geno-error-coeff 1.0 --geno-error-offset 0.05 --out $DEMUXLET_OUTDIR/demuxlet --sm-list $INDS
+      singularity exec Demuxafy.sif popscle demuxlet --plp $DEMUXLET_OUTDIR/pileup --vcf $VCF --field $FIELD --group-list $BARCODES ${CELL_TAG:+--tag-group $CELL_TAG} ${UMI_TAG:+--tag-UMI $UMI_TAG} --geno-error-coeff 1.0 --geno-error-offset 0.05 --out $DEMUXLET_OUTDIR/demuxlet --sm-list $INDS
 
     .. admonition:: HELP! It says my file/directory doesn't exist!
       :class: dropdown
@@ -166,7 +176,7 @@ Once you have run ``popscle pileup``, you can demultiplex your samples:
 
     .. code-block:: bash
 
-      singularity exec Demuxafy.sif popscle demuxlet --plp $DEMUXLET_OUTDIR/pileup --vcf $VCF --field $FIELD --group-list $BARCODES --geno-error-coeff 1.0 --geno-error-offset 0.05 --out $DEMUXLET_OUTDIR/demuxlet
+      singularity exec Demuxafy.sif popscle demuxlet --plp $DEMUXLET_OUTDIR/pileup --vcf $VCF --field $FIELD --group-list $BARCODES ${CELL_TAG:+--tag-group $CELL_TAG} ${UMI_TAG:+--tag-UMI $UMI_TAG} --geno-error-coeff 1.0 --geno-error-offset 0.05 --out $DEMUXLET_OUTDIR/demuxlet
 
     .. admonition:: HELP! It says my file/directory doesn't exist!
       :class: dropdown

--- a/docs/source/Dropulation.rst
+++ b/docs/source/Dropulation.rst
@@ -51,6 +51,17 @@ This is the data that you will need to have prepare to run Dropulation_:
     - For example, this is the :download:`individual file <_download_files/Individuals.txt>` for our example dataset
 
 
+.. admonition:: Optional
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding cell barcode (``$CELL_TAG``)
+
+      - If not specified, _Demuxlet defaults to using ``XC``.
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding unique molecular identifier (UMI) (``$UMI_TAG``)
+
+      - If not specified, _Demuxlet defaults to using ``XM``.
+
+
 Run Dropulation
 -----------------
 First, let's assign the variables that will be used to execute each step.
@@ -70,6 +81,8 @@ First, let's assign the variables that will be used to execute each step.
       DROPULATION_OUTDIR=/path/to/output/dropulation
       INDS=/path/to/TestData4PipelineFull/donor_list.txt
       GTF=/path/to/genes.gtf
+      CELL_TAG=CB  # default: XC
+      UMI_TAG=UB  # default: XM
 
 
 Bam Annotation
@@ -113,12 +126,6 @@ Dropulation Assignment
 
 First, we will identify the most likely singlet donor for each droplet.
 
-.. admonition:: Note
-  :class: note
-
-  Please change the cell barcode and molecular barcode tags as necessary. 
-  For 10x experiments processed with cellranger, this should be 'CB' for the ``CELL_BARCODE_TAG`` and 'UB' for the ``MOLECULAR_BARCODE_TAG``
-
 .. admonition:: note
 
   If you are submitting this job to an cluster to run, you may have to bind the ``$TMPDIR`` directory used by your cluster in the singularity command.
@@ -133,8 +140,8 @@ Please note that the ``\`` at the end of each line is purely for readability to 
             --OUTPUT $DROPULATION_OUTDIR/assignments.tsv.gz \
             --VCF $VCF \
             --SAMPLE_FILE $INDS \
-            --CELL_BARCODE_TAG 'CB' \
-            --MOLECULAR_BARCODE_TAG 'UB' \
+            ${CELL_TAG:+--CELL_BARCODE_TAG $CELL_TAG} \
+            ${UMI_TAG:+--MOLECULAR_BARCODE_TAG $UMI_TAG} \
             --VCF_OUTPUT $DROPULATION_OUTDIR/assignment.vcf \
             --MAX_ERROR_RATE 0.05
 
@@ -160,12 +167,6 @@ Dropulation Doublet
 
 Next, we will identify the likelihoods of each droplet being a doublet.
 
-.. admonition:: Note
-  :class: note
-
-  Please change the cell barcode and molecular barcode tags as necessary. 
-  For 10x experiments processed with cellranger, this should be 'CB' for the ``CELL_BARCODE_TAG`` and 'UB' for the ``MOLECULAR_BARCODE_TAG``
-
 .. admonition:: note
 
   If you are submitting this job to an cluster to run, you may have to bind the ``$TMPDIR`` directory used by your cluster in the singularity command.
@@ -179,8 +180,8 @@ Please note that the ``\`` at the end of each line is purely for readability to 
             --INPUT_BAM $DROPULATION_OUTDIR/possorted_genome_bam_dropulation_tag.bam \
             --OUTPUT $DROPULATION_OUTDIR/likelihoods.tsv.gz \
             --VCF $VCF \
-            --CELL_BARCODE_TAG 'CB' \
-            --MOLECULAR_BARCODE_TAG 'UB' \
+            ${CELL_TAG:+--CELL_BARCODE_TAG $CELL_TAG} \
+            ${UMI_TAG:+--MOLECULAR_BARCODE_TAG $UMI_TAG} \
             --SINGLE_DONOR_LIKELIHOOD_FILE $DROPULATION_OUTDIR/assignments.tsv.gz \
             --SAMPLE_FILE $INDS \
             --MAX_ERROR_RATE 0.05

--- a/docs/source/Freemuxlet.rst
+++ b/docs/source/Freemuxlet.rst
@@ -42,6 +42,17 @@ This is the data that you will need to have prepare to run Freemuxlet_:
   - Output directory (``$FREEMUXLET_OUTDIR``)
 
 
+.. admonition:: Optional
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding cell barcode (``$CELL_TAG``)
+
+      - If not specified, _Freemuxlet defaults to using ``CB``.
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding unique molecular identifier (UMI) (``$UMI_TAG``)
+
+      - If not specified, _Freemuxlet defaults to using ``UB``.
+
+
 
 
 Run Freemuxlet
@@ -80,6 +91,8 @@ First we will need to identify the number of reads from each allele at each of t
   --sam $BAM \
   --vcf $VCF \
   --group-list $BARCODES \
+  ${CELL_TAG:+--tag-group $CELL_TAG} \
+  ${UMI_TAG:+--tag-UMI $UMI_TAG} \
   --out $FREEMUXLET_OUTDIR/pileup
 
 .. admonition:: HELP! It says my file/directory doesn't exist!
@@ -117,7 +130,7 @@ Once you have run ``popscle pileup``, you can demultiplex your samples with Free
 
 .. code-block:: bash
 
-  singularity exec Demuxafy.sif popscle freemuxlet --plp $FREEMUXLET_OUTDIR/pileup --out $FREEMUXLET_OUTDIR/freemuxlet --group-list $BARCODES --nsample $N
+  singularity exec Demuxafy.sif popscle freemuxlet --plp $FREEMUXLET_OUTDIR/pileup --out $FREEMUXLET_OUTDIR/freemuxlet --group-list $BARCODES ${CELL_TAG:+--tag-group $CELL_TAG} ${UMI_TAG:+--tag-UMI $UMI_TAG} --nsample $N
 
 .. admonition:: HELP! It says my file/directory doesn't exist!
   :class: dropdown

--- a/docs/source/Souporcell.rst
+++ b/docs/source/Souporcell.rst
@@ -51,6 +51,16 @@ This is the data that you will need to have prepare to run Souporcell_:
   - Output directory (``$SOUPORCELL_OUTDIR``)
 
 
+.. admonition:: Optional
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding cell barcode (``$CELL_TAG``)
+
+      - If not specified, _Souporcell defaults to using ``CB``.
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding unique molecular identifier (UMI) (``$UMI_TAG``)
+
+      - If not specified, _Souporcell defaults to using ``UB``.
+
 
 Run Souporcell
 ---------------
@@ -97,6 +107,8 @@ You can run Souporcell_ with or without reference SNP genotypes - follow the ins
         -f $FASTA \
         -t $THREADS \
         -o $SOUPORCELL_OUTDIR \
+        ${CELL_TAG:+--cell_tag $CELL_TAG} \
+        ${UMI_TAG:+--umi_tag $UMI_TAG} \
         -k $N \
         --common_variants $VCF
 
@@ -119,6 +131,8 @@ You can run Souporcell_ with or without reference SNP genotypes - follow the ins
         -f $FASTA \
         -t $THREADS \
         -o $SOUPORCELL_OUTDIR \
+        ${CELL_TAG:+--cell_tag $CELL_TAG} \
+        ${UMI_TAG:+--umi_tag $UMI_TAG} \
         -k $N \
         --known_genotypes $VCF \
         --known_genotypes_sample_names donor1 donor donor3 donor4

--- a/docs/source/Vireo.rst
+++ b/docs/source/Vireo.rst
@@ -48,6 +48,22 @@ This is the data that you will need to have preparede to run Vireo_:
   - Output directory (``$VIREO_OUTDIR``)
   
 
+.. admonition:: Optional
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding cell barcode (``$CELL_TAG``)
+
+      - If not specified, _Vireo defaults to using ``CB``.
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding unique molecular identifier (UMI) (``$UMI_TAG``)
+
+      - If not specified, _Vireo defaults to using ``UR``.
+..
+  Note: The default switched from ``UR`` to ``UB`` with cellsnp-lite v.1.2.3.
+  The Demuxafy Singularity image v. 2.0.1 bundles cellsnp-lite v.1.2.1, so the
+  old default applies. The above documentation should be updated to reflect the
+  upstream change, once cellsnp-lite is updated to v.1.2.3 or higher in the
+  Demuxafy Singularity image.
+
 
 
 
@@ -92,6 +108,8 @@ Please note that the ``\`` at the end of each line is purely for readability to 
     -p 20 \ ## number of parallel processors
     --minMAF 0.1 \
     --minCOUNT 20 \
+    ${CELL_TAG:+--cellTAG $CELL_TAG} \
+    ${UMI_TAG:+--UMItag $UMI_TAG} \
     --gzip 
 
 You can alter the ``-p``, ``--minMAF`` and ``--minCOUNT`` parameters to fit your data and your needs.

--- a/docs/source/scSplit.rst
+++ b/docs/source/scSplit.rst
@@ -38,6 +38,13 @@ This is the data that you will need to have prepared to run ScSplit_:
   - Output directory (``$SCSPLIT_OUTDIR``)
 
 
+.. admonition:: Optional
+
+    - The SAM tag used in the Bam file to annotate the aligned single cell reads with their corresponding cell barcode (``$CELL_TAG``)
+
+      - If not specified, _ScSplit defaults to using ``CB``.
+
+
 Run ScSplit
 -----------
 First, let's assign the variables that will be used to execute each step.
@@ -142,7 +149,7 @@ The prepared SNV genotypes and bam file can then be used to demultiplex and call
 
 .. code-block:: bash
 
-  singularity exec Demuxafy.sif scSplit count -c $VCF -v $SCSPLIT_OUTDIR/freebayes_var_qual30.recode.vcf -i $SCSPLIT_OUTDIR/filtered_bam_dedup_sorted.bam -b $BARCODES -r $SCSPLIT_OUTDIR/ref_filtered.csv -a $SCSPLIT_OUTDIR/alt_filtered.csv -o $SCSPLIT_OUTDIR
+  singularity exec Demuxafy.sif scSplit count -c $VCF -v $SCSPLIT_OUTDIR/freebayes_var_qual30.recode.vcf -i $SCSPLIT_OUTDIR/filtered_bam_dedup_sorted.bam -b $BARCODES ${CELL_TAG:+-t $CELL_TAG} -r $SCSPLIT_OUTDIR/ref_filtered.csv -a $SCSPLIT_OUTDIR/alt_filtered.csv -o $SCSPLIT_OUTDIR
   singularity exec Demuxafy.sif scSplit run -r $SCSPLIT_OUTDIR/ref_filtered.csv -a $SCSPLIT_OUTDIR/alt_filtered.csv -n $N -o $SCSPLIT_OUTDIR
   singularity exec Demuxafy.sif scSplit genotype -r $SCSPLIT_OUTDIR/ref_filtered.csv -a $SCSPLIT_OUTDIR/alt_filtered.csv -p $SCSPLIT_OUTDIR/scSplit_P_s_c.csv -o $SCSPLIT_OUTDIR
 

--- a/scripts/Demuxalot.py
+++ b/scripts/Demuxalot.py
@@ -52,13 +52,12 @@ print("loading barcodes")
 barcode_handler = BarcodeHandler.from_file(args.barcodes, tag=args.celltag)
 
 parse_read_custom = lambda read: parse_read(read, umi_tag = args.umitag)
-
 snps = count_snps(
     bamfile_location = args.bamfile,
     chromosome2positions=genotypes.get_chromosome2positions(),
     barcode_handler=barcode_handler, 
     joblib_n_jobs=args.nproc,
-    parse_read=parse_read_custom
+    parse_read=parse_read_custom,
 )
 
 print("estimating posterior probs and likelihoods")


### PR DESCRIPTION
Cell Ranger uses `CB` SAM tags for the cell barcode and `UB` SAM tags for the UMI but other scRNA-seq pipelines use different tags (*e.g.* `XC` and `XM`).
This commit introduces the `CELL_TAG` and `UMI_TAG` environment variables to override the Cell Ranger style defaults.

Note: For Demuxalot, this requires upstream changes ~suggested in the following PR: herophilus/demuxalot#26~introduced in `v.0.4.1`. Therefore, it ~not only~ does ~it~ depend ~on that one to be merged ([which should happen 'soon'](https://github.com/herophilus/demuxalot/pull/24#issuecomment-1962282889)), but also~ on updating the Demuxalot version bundled in the Demuxafy Singularity Image to one including those upstream changes (`>= v.0.4.1`). ~Thus, this PR must not be merged before #46 (or, IMHO better: #47) is merged as well.~

---
@drneavin: Merging this and releasing a new version would enable me to use Demuxafy on a lot of data we already have analysed without having to re-analyse them all from scratch with Cell Ranger. I have tested those changes locally using the (reduced) test dataset as well as one of my non- Cell Ranger datasets.