### PR TITLE
Fix newline escaping

### DIFF
--- a/docs/source/Demuxlet.rst
+++ b/docs/source/Demuxlet.rst
@@ -100,7 +100,7 @@ Please note that the ``\`` at the end of each line is purely for readability to 
               --vcf $VCF \
               --group-list $BARCODES \
               --tag-group $CELL_TAG \
-              --tag-UMI $UMI_TAG
+              --tag-UMI $UMI_TAG \
               --out $DEMUXLET_OUTDIR/pileup \
               --sm-list $INDS
 


### PR DESCRIPTION
This adds back a `\` escaping a newline within a command that was accidentally removed in commit 210b85f82fb33f0d7bf7c45c32b56701e204edfa.